### PR TITLE
[lg-1] Add file appender

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,27 @@
+<configuration>
+
+    <property name="DIR" value="../logs"/>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <appender name="rollingFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${DIR}/movieland.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${DIR}/movieland-%d{yyyy-MM-dd}.log.%i</fileNamePattern>
+            <maxFileSize>5MB</maxFileSize>
+            <maxHistory>60</maxHistory>
+            <totalSizeCap>20GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="Console"/>
+        <appender-ref ref="rollingFileAppender"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Configure file appender for logback.
1. All logs, starting from level DEBUG in your application, should be stored in file.
2. For file name, use next pattern: 
- current log: movieland.log
- previous logs: movieland-[yyyy-MM-dd].log[.log_number], for example:
movieland-2017-10-15.log.0 - for first log file which was published on 2017-10-15
3. Maximum size of log file is 5mb.